### PR TITLE
Ensure we get the correct URL if you are using Pro

### DIFF
--- a/polyglot/deepl.py
+++ b/polyglot/deepl.py
@@ -27,7 +27,7 @@ class Deepl:
 
     @property
     def __base_url(self) -> str:
-        version: str = "" if self.__license.version == "pro" else "-free"
+        version: str = "" if self.__license.version == license.LicenseVersion.PRO else "-free"
         return f"https://api{version}.deepl.com/v2/"
 
     @property


### PR DESCRIPTION
The code seems to compare the string "pro" with the class constant
License.PRO - this fix should take care of that mis-match.

Thanks for the useful software! Very much appreciated.